### PR TITLE
Fix #1 - TYPE-ERROR on SBCL 1.3.4

### DIFF
--- a/src/server.lisp
+++ b/src/server.lisp
@@ -69,7 +69,7 @@
   "Start the server. Returns a handler object."
   (let ((handler (make-instance 'hunchensocket:websocket-acceptor
                                 :port port
-                                :websocket-timeout 100000000)))
+                                :websocket-timeout #x1FFFFF)))
     (push (lambda (request)
             (declare (ignore request))
             server)


### PR DESCRIPTION
Fix #1  - TYPE-ERROR on SBCL 1.3.4
Reduced the websocket timeout to the largest acceptable value.
