### PR TITLE
Adjustable timeout

### DIFF
--- a/src/client.lisp
+++ b/src/client.lisp
@@ -26,10 +26,10 @@
                 (funcall (client-on-message client) client message)))
     client))
 
-(defun send (client text)
+(defun send (client text &key callback)
   "Send text to the server."
   (with-slots (ws) client
-    (wsd:send ws text)))
+    (wsd:send ws text :callback callback)))
 
 (defmacro with-client-connection ((client) &body body)
   (let ((c (gensym)))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -67,12 +67,13 @@
   (funcall (on-message server) server message))
 
 (defparameter +default-address+ "0.0.0.0")
+(defparameter +default-timeout+ 300)
 
-(defun start (server port &key (address +default-address+))
+(defun start (server port &key (address +default-address+) (timeout +default-timeout+))
   "Start the server. Returns a handler object."
   (let ((handler (make-instance 'hunchensocket:websocket-acceptor
                                 :port port
-                                :websocket-timeout 10000)))
+                                :websocket-timeout timeout)))
     (push (lambda (request)
             (declare (ignore request))
             server)

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -7,7 +7,8 @@
            :send
            :start
            :stop
-           :+default-address+)
+           :+default-address+
+           :+default-timeout+)
   (:documentation "Trivial WebSockets."))
 (in-package :trivial-ws)
 

--- a/t/trivial-ws.lisp
+++ b/t/trivial-ws.lisp
@@ -35,7 +35,7 @@
     (trivial-ws.client:with-client-connection (client)
       (pass "Client connected")
       (sleep 1)
-      (ok (trivial-ws.client:send client "ping") "Send message")))
+      (ok (trivial-ws.client:send client "ping" :callback (lambda () t)) "Send message")))
   (ok (trivial-ws:stop handler) "Stop server")
   (sleep 1)
   (ok connectedp "Connected")

--- a/t/trivial-ws.lisp
+++ b/t/trivial-ws.lisp
@@ -21,7 +21,7 @@
                                 (trivial-ws:send (first (trivial-ws:clients server))
                                                  message))))
        (handler)
-       (address "0.0.0.0")
+       (address "127.0.0.1")
        (port (find-port:find-port)))
   (ok (setf handler (trivial-ws:start server port :address address)) "Start server")
   (let ((client))

--- a/trivial-ws.asd
+++ b/trivial-ws.asd
@@ -6,8 +6,7 @@
   :homepage "https://github.com/ceramic/trivial-ws"
   :bug-tracker "https://github.com/ceramic/trivial-ws/issues"
   :source-control (:git "git@github.com:ceramic/trivial-ws.git")
-  :depends-on (:hunchensocket
-               :cl-async)
+  :depends-on (:hunchensocket)
   :components ((:module "src"
                 :serial t
                 :components


### PR DESCRIPTION
Add an ability to set the WS timeout as required. The default timeout value is set to 300 seconds to match the corresponding default value in hunchenscoket and other packages.